### PR TITLE
Add original cron definition as an attribute

### DIFF
--- a/crontab.gemspec
+++ b/crontab.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'crontab'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.author = 'OZAWA Sakuro'
   s.email = 'github@2238club.org'
   s.homepage = 'http://github.com/sakuro/crontab'

--- a/lib/crontab/entry.rb
+++ b/lib/crontab/entry.rb
@@ -6,12 +6,13 @@ class Crontab
     # * <tt>schedule</tt> A Crontab::Schedule instance.
     # * <tt>command</tt>
     # * <tt>uid</tt>
-    def initialize(schedule, command, uid=nil)
+    def initialize(schedule, command, cron_definition, uid=nil)
       raise ArgumentError, 'invalid schedule' unless schedule.is_a? Schedule
       raise ArgumentError, 'invalid command' unless command.is_a? String
 
       @schedule = schedule.freeze
       @command = command.freeze
+      @cron_definition = cron_definition.freeze
       @uid =
         case uid
         when String
@@ -25,7 +26,7 @@ class Crontab
         end
     end
 
-    attr_reader :schedule, :command, :uid
+    attr_reader :schedule, :command, :cron_definition, :uid
     class << self
       # Parses a string line in crontab(5) job format.
       #
@@ -40,9 +41,10 @@ class Crontab
         words = line.split(/\s+/, number_of_fields)
         command = words.pop
         uid = options[:system] ? words.pop : Process.uid
+        cron_definition = words.first(5).join(' ')
         spec = words.join(' ')
         schedule = Crontab::Schedule.new(spec)
-        new(schedule, command, uid)
+        new(schedule, command, cron_definition, uid)
       end
     end
   end

--- a/spec/crontab/entry_spec.rb
+++ b/spec/crontab/entry_spec.rb
@@ -5,25 +5,26 @@ require 'crontab/schedule'
 describe Crontab::Entry do
   describe 'when instantiating' do
     before :each do
-      @schedule = Crontab::Schedule.new('0 0 * * *') # @daily
+      @cron_definition = '0 0 * * *'
+      @schedule = Crontab::Schedule.new(@cron_definition) # @daily
       @command = 'echo hello'
     end
 
     it 'should accpet Crontab::Schedule and command String' do
-      entry = Crontab::Entry.new(@schedule, @command)
+      entry = Crontab::Entry.new(@schedule, @command, @cron_definition)
       entry.uid.should == Process.uid
     end
 
     it 'should accpet Crontab::Schedule, command String and user String' do
       uid = Process.uid
       user = Etc.getpwuid(uid)
-      entry = Crontab::Entry.new(@schedule, @command, user.name)
+      entry = Crontab::Entry.new(@schedule, @command, @cron_definition, user.name)
       entry.uid.should == uid
     end
 
     it 'should accpet Crontab::Schedule, command String and user ID' do
       uid = Process.uid
-      entry = Crontab::Entry.new(@schedule, @command, uid)
+      entry = Crontab::Entry.new(@schedule, @command, @cron_definition, uid)
       entry.uid.should == uid
     end
 
@@ -95,7 +96,9 @@ describe Crontab::Entry do
       @other_schedule = Crontab::Schedule.new('@monthly')
       @command = 'ehco hello'
       @other_command = 'echo bonjour'
-      @entry = Crontab::Entry.new(@schedule, @command)
+      @cron_definition = '0 0 * * *'
+      @other_cron_definition = '0,30 0 * * *'
+      @entry = Crontab::Entry.new(@schedule, @command, @cron_definition)
     end
 
     it 'should be read-accessible to schedule' do
@@ -123,6 +126,16 @@ describe Crontab::Entry do
       Process.uid.should_not == 0 and
       lambda { @entry.uid = 0 }.should raise_error(NoMethodError)
       @entry.uid.should == Process.uid
+    end
+
+    it 'should be freeze cron_definition' do
+      @entry.cron_definition.should be_frozen
+    end
+
+    it 'should be read-accessible to cron_definition' do
+      @entry.cron_definition == @cron_definition and
+      lambda { @entry.cron_definition = @other_cron_definition }.should raise_error(NoMethodError)
+      @entry.cron_definition == @cron_definition
     end
   end
 end


### PR DESCRIPTION
This pull request add an attribute `cron_definition` to every entry.
